### PR TITLE
fix(docs.js): use link tag for CSS files

### DIFF
--- a/docs/js/docs.js
+++ b/docs/js/docs.js
@@ -32,7 +32,14 @@ docsApp.directive.ngHtmlWrapLoaded = function(reindentCode, templateMerge, loade
         html = "<!doctype html>\n<html ng-app{{module}}>\n  <head>\n{{head:4}}  </head>\n  <body>\n{{body:4}}  </body>\n</html>";
 
       angular.forEach(loadedUrls.base, function(dep) {
-        properties.head += '<script src="' + dep + '"></script>\n';
+        if (!dep) return;
+        var ext = dep.split(/\./).pop();
+
+        if (ext === 'css') {
+          properties.head += '<link rel="stylesheet" href="' + dep + '" type="text/css">\n';
+        } else if(ext === 'js') {
+          properties.head += '<script src="' + dep + '"></script>\n';
+        }
       });
 
       angular.forEach((attr.ngHtmlWrapLoaded || '').split(' '), function(dep) {

--- a/src/templates/js/docs.js
+++ b/src/templates/js/docs.js
@@ -32,7 +32,14 @@ docsApp.directive.ngHtmlWrapLoaded = function(reindentCode, templateMerge, loade
         html = "<!doctype html>\n<html ng-app{{module}}>\n  <head>\n{{head:4}}  </head>\n  <body>\n{{body:4}}  </body>\n</html>";
 
       angular.forEach(loadedUrls.base, function(dep) {
-        properties.head += '<script src="' + dep + '"></script>\n';
+        if (!dep) return;
+        var ext = dep.split(/\./).pop();
+
+        if (ext === 'css') {
+          properties.head += '<link rel="stylesheet" href="' + dep + '" type="text/css">\n';
+        } else if(ext === 'js') {
+          properties.head += '<script src="' + dep + '"></script>\n';
+        }
       });
 
       angular.forEach((attr.ngHtmlWrapLoaded || '').split(' '), function(dep) {


### PR DESCRIPTION
Update logic for ngHtmlWrapLoaded to use link tag for any files with a CSS extension.

closes #14